### PR TITLE
Fix typo in `expo-splash-screen` Android install

### DIFF
--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -323,7 +323,7 @@ public class MainActivity extends ReactActivity {
 ```
 
 
-#### `res/drawable/splashscreen_background.png`
+#### `res/drawable/splashscreen_image.png`
 
 You have to provide your splash screen image and place it under the `res/drawable` directory.
 This image will be loaded as soon as Android mounts your application's native view hierarchy.


### PR DESCRIPTION
# Why

After following the setup on installation of `expo-splash-screen` on bare workflow, in Android the splash image does not appear, only the background color is correct configured.

# How

There is a typo in the does about the file be created with `res/drawable/splashscreen_background.png` name, but the correct location should be `res/drawable/splashscreen_image.png`.

# Test Plan

1. Start a new Bare project: $ expo init --template bare-minimum
2. Install expo-splash-screen using $ expo install expo-splash-screen
3. Configure expo-splash-screen for Android: https://github.com/expo/expo/tree/master/packages/expo-splash-screen#-configure-android
4. Run project on Emulator/Device using $ react-native run-android
5. Correct configured image should appear on SplashScreen

